### PR TITLE
Fix max current error

### DIFF
--- a/src/pd_sink.cpp
+++ b/src/pd_sink.cpp
@@ -143,7 +143,7 @@ bool pd_sink::update_protocol()
     } else {
         protocol_ = pd_protocol::usb_20;
         active_voltage = 5000;
-        active_voltage = 900;
+        active_max_current = 900;
         num_source_caps = 0;
     }
 


### PR DESCRIPTION
I have absolutely no experience with this module so maybe this change I'm requesting is wrong - if it is, sorry for wasting your time. 

But this code for non-PD USB2 support looks wrong, it first sets `active_voltage` to 5000 (5 V), and then immediately afterwards it sets `active_voltage` down to 900 (900 mV). 

This looks a lot like a typo and the code was supposed to set `active_max_current` to 900 (900 mA) instead.